### PR TITLE
Changing " to '

### DIFF
--- a/core/src/components/action-sheet/usage/angular.md
+++ b/core/src/components/action-sheet/usage/angular.md
@@ -13,7 +13,7 @@ export class ActionSheetExample {
 
   async presentActionSheet() {
     const actionSheet = await this.actionSheetController.create({
-      header: "Albums",
+      header: 'Albums',
       buttons: [{
         text: 'Delete',
         role: 'destructive',


### PR DESCRIPTION
The header value was using ".

#### Short description of what this resolves:
tslint was highlighting this as an issue.

#### Changes proposed in this pull request:

" => '

**Ionic Version**: 1.x / 2.x / 3.x / 4.x
4.x
**Fixes**: #
-